### PR TITLE
Redefines AVCODEC_MAX_AUDIO_FRAME_SIZE which is depricated

### DIFF
--- a/src/ffmpeg.cc
+++ b/src/ffmpeg.cc
@@ -8,7 +8,7 @@
 // Somehow ffmpeg headers give errors that these are not defined...
 #define INT64_C Q_INT64_C
 #define UINT64_C Q_UINT64_C
-
+#define AVCODEC_MAX_AUDIO_FRAME_SIZE 192000
 extern "C" {
 #include AVCODEC_INCLUDE
 #include AVFORMAT_INCLUDE


### PR DESCRIPTION
Solves the following issue while building: [Source](https://github.com/chelyaev/ffmpeg-tutorial/issues/13)

```
[ 97%] [100%] Building CXX object src/CMakeFiles/composer.dir/moc_synth.cpp.o
Building CXX object src/CMakeFiles/composer.dir/qrc_editor.cpp.o
/home/tom/Static/Software/composer/src/ffmpeg.cc: In member function ‘void FFmpeg::decodeNextFrame()’:
/home/tom/Static/Software/composer/src/ffmpeg.cc:146:51: error: ‘AVCODEC_MAX_AUDIO_FRAME_SIZE’ was not declared in this scope
  std::vector<char, AvMalloc<char> > decodedBuffer(AVCODEC_MAX_AUDIO_FRAME_SIZE);
                                                   ^
/home/tom/Static/Software/composer/src/ffmpeg.cc:156:25: warning: ‘AVFrame* avcodec_alloc_frame()’ is deprecated (declared at /usr/local/include/libavcodec/avcodec.h:3231) [-Wdeprecated-declarations]
      AVFrame* m_frame = avcodec_alloc_frame();
                         ^
/home/tom/Static/Software/composer/src/ffmpeg.cc:156:45: warning: ‘AVFrame* avcodec_alloc_frame()’ is deprecated (declared at /usr/local/include/libavcodec/avcodec.h:3231) [-Wdeprecated-declarations]
      AVFrame* m_frame = avcodec_alloc_frame();
                                             ^
make[2]: *** [src/CMakeFiles/composer.dir/ffmpeg.cc.o] Error 1
make[1]: *** [src/CMakeFiles/composer.dir/all] Error 2
make: *** [all] Error 2
```
