### PR TITLE
Add Support for FFmpeg version 5.0..7.1.1

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -17,7 +17,7 @@ jobs:
   # Create the AppImage
   AppImage:
     name: Create the AppImage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install the AppImage bundler and Performous deps
         id: fetch_deps
@@ -26,11 +26,11 @@ jobs:
           chmod +x appimage-builder-x86_64.AppImage
           sudo mv appimage-builder-x86_64.AppImage /usr/local/bin/appimage-builder
           sudo apt update
-          sudo apt-get install -y --no-install-recommends git cmake build-essential gettext help2man libavcodec-dev libavformat-dev libswscale-dev qtbase5-dev qtmultimedia5-dev ca-certificates file
+          sudo apt-get install -y --no-install-recommends git cmake build-essential gettext help2man libavcodec-dev libavformat-dev libswscale-dev qtbase5-dev qtmultimedia5-dev ca-certificates file libfuse2
 
       - name: Checkout Git
         id: checkout_git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build the AppImage
         id: build_appimage
@@ -52,7 +52,7 @@ jobs:
 
       # Upload artifacts during pull-requests
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'pull_request' }}
         with:
           name: ${{ env.ARTIFACT_NAME }}
@@ -61,7 +61,7 @@ jobs:
       # Upload artifacts on master
       - name: Upload artifact with unified name
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.MASTER_ARTIFACT_NAME }}
           path: ${{ env.MASTER_ARTIFACT_PATH }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -55,18 +55,22 @@ jobs:
             version: 20.04
           - os: ubuntu
             version: 22.04
+          - os: ubuntu
+            version: 24.04
           - os: debian
-            version: 10
-          - os: debian
-            version: 11
+            version: 12
           - os: fedora
-            version: 34
+            version: 36
           - os: fedora
-            version: 35
-          ## FFMPEG5 causes issues
-          ## See https://github.com/performous/composer/issues/45
-          #- os: fedora
-          #  version: 36
+            version: 37
+          - os: fedora
+            version: 38
+          - os: fedora
+            version: 39
+          - os: fedora
+            version: 40
+          - os: fedora
+            version: 41
     steps:
       - name: Container name
         run: |
@@ -75,10 +79,10 @@ jobs:
           echo "CONTAINER_NAME=${BUILD_CONTAINER}" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to the container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REPO_NAME }}
@@ -129,7 +133,7 @@ jobs:
 
       # Upload artifacts during pull-requests
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'pull_request' }}
         with:
           name: ${{ env.ARTIFACT_NAME }}
@@ -138,7 +142,7 @@ jobs:
       # Upload artifacts on master
       - name: Upload artifact with unified name
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.MASTER_ARTIFACT_NAME }}
           path: ${{ env.MASTER_ARTIFACT_PATH }}
@@ -157,7 +161,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Push container
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         # Containers can't be pushed during PRs because of the way permissions
         # are delegated to secrets.GITHUB_TOKEN
         if: ${{ needs.determine_docker_build.outputs.build_docker_containers == 'true' && github.event_name != 'pull_request' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
+cmake_minimum_required(VERSION 3.10)
+cmake_policy(VERSION 3.10)
 project("Composer" CXX C)
-cmake_minimum_required(VERSION 3.0)
-cmake_policy(VERSION 3.0)
 set(PROJECT_VERSION "2.0.1")
 set(BUILD_SHARED_LIBS OFF)
 #FIXME: Changes in version number or project name must manually also be put to:

--- a/README.md
+++ b/README.md
@@ -21,10 +21,14 @@ Latest builds
 ==========
 - [Linux - Ubuntu 20.04](https://nightly.link/performous/composer/workflows/build_and_release/master/Composer-latest-ubuntu_20.04.deb.zip)
 - [Linux - Ubuntu 22.04](https://nightly.link/performous/composer/workflows/build_and_release/master/Composer-latest-ubuntu_22.04.deb.zip)
-- [Linux - Debian 10](https://nightly.link/performous/composer/workflows/build_and_release/master/Composer-latest-debian_10.deb.zip)
-- [Linux - Debian 11](https://nightly.link/performous/composer/workflows/build_and_release/master/Composer-latest-debian_11.deb.zip)
-- [Linux - Fedora 34](https://nightly.link/performous/composer/workflows/build_and_release/master/Composer-latest-fedora_34.rpm.zip)
-- [Linux - Fedora 35](https://nightly.link/performous/composer/workflows/build_and_release/master/Composer-latest-fedora_35.rpm.zip)
+- [Linux - Ubuntu 24.04](https://nightly.link/performous/composer/workflows/build_and_release/master/Composer-latest-ubuntu_24.04.deb.zip)
+- [Linux - Debian 12](https://nightly.link/performous/composer/workflows/build_and_release/master/Composer-latest-debian_12.deb.zip)
+- [Linux - Fedora 36](https://nightly.link/performous/composer/workflows/build_and_release/master/Composer-latest-fedora_36.rpm.zip)
+- [Linux - Fedora 37](https://nightly.link/performous/composer/workflows/build_and_release/master/Composer-latest-fedora_37.rpm.zip)
+- [Linux - Fedora 38](https://nightly.link/performous/composer/workflows/build_and_release/master/Composer-latest-fedora_38.rpm.zip)
+- [Linux - Fedora 39](https://nightly.link/performous/composer/workflows/build_and_release/master/Composer-latest-fedora_39.rpm.zip)
+- [Linux - Fedora 40](https://nightly.link/performous/composer/workflows/build_and_release/master/Composer-latest-fedora_40.rpm.zip)
+- [Linux - Fedora 41](https://nightly.link/performous/composer/workflows/build_and_release/master/Composer-latest-fedora_41.rpm.zip)
 - [Linux - AppImage](https://nightly.link/performous/composer/workflows/build_and_release/master/Composer-latest.AppImage.zip)
 
 Build & Install

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.0)
-cmake_policy(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
+cmake_policy(VERSION 3.10)
 
 set(EXENAME ${CMAKE_PROJECT_NAME})
 set(CMAKE_AUTOMOC FALSE)
@@ -40,8 +40,8 @@ target_sources(${EXENAME} PRIVATE ${HEADER_FILES} ${SOURCE_FILES} ${MOC_SOURCES}
 # Generate config.hh
 configure_file(config.cmake.hh "${CMAKE_BINARY_DIR}/src/config.hh" @ONLY)
 
-include_directories(${CMAKE_BINARY_DIR}/src)
-include_directories(${CMAKE_SOURCE_DIR}/src)
+target_include_directories(${EXENAME} PRIVATE ${CMAKE_BINARY_DIR}/src)
+target_include_directories(${EXENAME} PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
 # We don't currently have any assets, so on Windows, we just install to the root installation folder
 if(UNIX)

--- a/src/config.cmake.hh
+++ b/src/config.cmake.hh
@@ -13,11 +13,13 @@
 
 // FFMPEG libraries use changing include file names... Get them from CMake.
 #define AVCODEC_INCLUDE <@AVCodec_INCLUDE@>
+#define AVCODEC_CODEC_PAR_INCLUDE <libavcodec/codec_par.h>
 #define AVFORMAT_INCLUDE <@AVFormat_INCLUDE@>
 #define SWRESAMPLE_INCLUDE <@SWResample_INCLUDE@>
 #define SWSCALE_INCLUDE <@SWScale_INCLUDE@>
 #define AVUTIL_INCLUDE <@AVUtil_INCLUDE@>
 #define AVUTIL_OPT_INCLUDE <libavutil/opt.h> //HACK to get AVOption class!
 #define AVUTIL_MATH_INCLUDE <libavutil/mathematics.h>
+#define AVUTIL_ERROR_INCLUDE <libavutil/error.h>
 
 #endif

--- a/src/ffmpeg.cc
+++ b/src/ffmpeg.cc
@@ -21,7 +21,7 @@ extern "C" {
 	#include AVUTIL_ERROR_INCLUDE
 }
 
-/*static*/ QMutex FFmpeg::s_avcodec_mutex;
+QMutex FFmpeg::s_avcodec_mutex;
 
 void AVFormatContextDeleter::operator ()(AVFormatContext* context) {
 	avformat_close_input(&context);
@@ -74,7 +74,8 @@ void FFmpeg::open() {
 
 	AVFormatContext *ps{};
 
-	if (auto err = avformat_open_input(&ps, m_filename.c_str(), NULL, NULL); err != 0)
+	auto err = avformat_open_input(&ps, m_filename.c_str(), NULL, NULL);
+	if (err != 0)
 		throw std::runtime_error(std::string("Cannot open input file. Error: ") + std::to_string(err) + " " + stringFromErrorCode(err));
 
 	pFormatCtx = {ps, {}};


### PR DESCRIPTION
### What does this PR do?
Updates the FFmpeg code in ffmpeg.cc and ffmpeg.hh so that the code used is using modern apis and makes it build with newer FFmpeg releases. Also made it so there are no deprecation warnings anymore in the versions tested.

### Motivation
The FFmpeg code in use no longer build with FFmpeg 5.0 or newer and for FFmpeg 3.1 and  newer it was giving deprecation warnings for functions that were being used.  This makes it easier for someone to develop on this project on a more modern system than one that comes with an FFmpeg version younger than 3.1.

### Additional Notes
I tested this in a Kubuntu 24.04 vm and tested all versions from 3.1 all the way up to the latest 7.1.1 release.
So that's 3.1, 3.2, 3.3, 3.4, 4.0, 4.1, 4.2, 4.3, 4.4, 5.0, 5.1, 6.0, 6.1, 7.0 and 7.1.
QT5 version on this machine is 5.15.13.

Because of removed apis this now no longer works with FFmpeg version 3.0 and lower.
